### PR TITLE
Rfm::Resultset not Rfm::Result::ResultSet

### DIFF
--- a/lib/rfm/utilities/factory.rb
+++ b/lib/rfm/utilities/factory.rb
@@ -20,7 +20,7 @@ module Rfm
       
       def all
         if !@loaded
-          Rfm::Result::ResultSet.new(@server, @server.connect(@server.state[:account_name], @server.state[:password], '-dbnames', {}).body).each {|record|
+          Rfm::Resultset.new(@server, @server.connect(@server.state[:account_name], @server.state[:password], '-dbnames', {}).body).each {|record|
             name = record['DATABASE_NAME']
             self[name] = Rfm::Database.new(name, @server) if self[name] == nil
           }
@@ -45,7 +45,7 @@ module Rfm
       
       def all
         if !@loaded
-          Rfm::Result::ResultSet.new(@server, @server.connect(@server.state[:account_name], @server.state[:password], '-layoutnames', {"-db" => @database.name}).body).each {|record|
+          Rfm::Resultset.new(@server, @server.connect(@server.state[:account_name], @server.state[:password], '-layoutnames', {"-db" => @database.name}).body).each {|record|
             name = record['LAYOUT_NAME']
             self[name] = Rfm::Layout.new(name, @database) if self[name] == nil
           }
@@ -70,7 +70,7 @@ module Rfm
       
       def all
         if !@loaded
-          Rfm::Result::ResultSet.new(@server, @server.connect(@server.state[:account_name], @server.state[:password], '-scriptnames', {"-db" => @database.name}).body).each {|record|
+          Rfm::Resultset.new(@server, @server.connect(@server.state[:account_name], @server.state[:password], '-scriptnames', {"-db" => @database.name}).body).each {|record|
             name = record['SCRIPT_NAME']
             self[name] = Rfm::Script.new(name, @database) if self[name] == nil
           }


### PR DESCRIPTION
references to Rfm:Resultset in Rfm::Factory classes were using Rfm::Result::ResultSet.
